### PR TITLE
Use hook scope names of rspec v2

### DIFF
--- a/lib/delta_test/spec_helpers.rb
+++ b/lib/delta_test/spec_helpers.rb
@@ -10,11 +10,11 @@ module DeltaTest
       $delta_test_generator ||= DeltaTest::Generator.new
       $delta_test_generator.setup!
 
-      example.before(:context) do
+      example.before(:all) do
         $delta_test_generator.start!(example.metadata[:file_path])
       end
 
-      example.after(:context) do
+      example.after(:all) do
         $delta_test_generator.stop!
       end
     end


### PR DESCRIPTION
## What

Use `:all` instead of `:context`


## Why

In RSpec 2.x:

https://www.relishapp.com/rspec/rspec-core/v/2-99/docs/hooks/before-and-after-hooks

> before(:each) # run before each example
> before(:all)  # run one time only, before all of the examples in a group
>
> after(:each) # run after each example
> after(:all)  # run one time only, after all of the examples in a group

In RSpec 3.2:

https://www.relishapp.com/rspec/rspec-core/v/3-2/docs/hooks/before-and-after-hooks

> Note: the :example and :context scopes are also available as :each and
> :all, respectively. Use whichever you prefer.



