### PR TITLE
Exit with real status

### DIFF
--- a/lib/delta_test/cli.rb
+++ b/lib/delta_test/cli.rb
@@ -174,8 +174,11 @@ module DeltaTest
       Open3.popen3(args) do |i, o, e, w|
         i.write(spec_files.join("\n")) if spec_files
         i.close
+
         o.each { |l| puts l }
         e.each { |l| $stderr.puts l }
+
+        exit w.value.exitstatus
       end
     end
 


### PR DESCRIPTION
## What

Fix `CLI#do_exec` to exit with real status code.



