### PR TITLE
Fail to obtain current spec file path with RSpec 2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ end
 namespace :rails do
   desc 'Run rails tests'
   task :test do
-    s = system('cd spec/rails && DELTA_TEST_ACTIVE=true bundle exec rspec')
+    s = system('cd spec/rails && DELTA_TEST_ACTIVE=true DELTA_TEST_VERBOSE=true bundle exec rspec')
     exit $? unless s
   end
 end

--- a/lib/delta_test/spec_helpers.rb
+++ b/lib/delta_test/spec_helpers.rb
@@ -11,7 +11,7 @@ module DeltaTest
       $delta_test_generator.setup!
 
       example.before(:all) do
-        $delta_test_generator.start!(example.metadata[:file_path])
+        $delta_test_generator.start!(example.file_path)
       end
 
       example.after(:all) do

--- a/spec/lib/delta_test/spec_helpers_spec.rb
+++ b/spec/lib/delta_test/spec_helpers_spec.rb
@@ -16,6 +16,10 @@ describe DeltaTest::SpecHelpers do
         def metadata
           { file_path: 'spec/foo/bar.rb' }
         end
+
+        def file_path
+          metadata[:file_path]
+        end
       end
     end
 


### PR DESCRIPTION
## Why

RSpec 2.14.8

```
     Failure/Error: Unable to find matching line from backtrace
     TypeError:
       no implicit conversion of nil into String
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/bundler/gems/delta_test-249c419ead8d/lib/delta_test/utils.rb:14:in `initialize'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/bundler/gems/delta_test-249c419ead8d/lib/delta_test/utils.rb:14:in `new'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/bundler/gems/delta_test-249c419ead8d/lib/delta_test/utils.rb:14:in `regulate_filepath'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/bundler/gems/delta_test-249c419ead8d/lib/delta_test/generator.rb:45:in `start!'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/bundler/gems/delta_test-249c419ead8d/lib/delta_test/spec_helpers.rb:14:in `block in use_delta_test'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/hooks.rb:21:in `instance_eval'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/hooks.rb:21:in `run'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/hooks.rb:119:in `run'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/hooks.rb:446:in `run_hook'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:331:in `block in run_before_all_hooks'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/memoized_helpers.rb:107:in `block in isolate_for_before_all'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/memoized_helpers.rb:103:in `instance_eval'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/memoized_helpers.rb:103:in `isolate_for_before_all'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:330:in `run_before_all_hooks'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/example_group.rb:370:in `run'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:28:in `block (2 levels) in run'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:28:in `map'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:28:in `block in run'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/reporter.rb:58:in `report'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:25:in `run'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:77:in `rescue in run'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:73:in `run'
     # /home/ubuntu/wantedly/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:17:in `block in autorun'
```

## What

- Use `example.file_path` instead of `example.metadata[:file_path]`