### PR TITLE
Run full tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,10 @@ commands:
 
     exec <script> [-- <files>]
                    Execute test script using delta_test.
-                   Run command something like `delta_test list | xargs script'.
+                   if <base> and <head> is the same commit or no dependencies table is found,
+                   it'll run full test cases with a profile mode to create a table.
+                   Otherwise, it'll run test script with only related spec files
+                   passed by its arguments, like `delta_test list | xargs script'.
 ```
 
 #### `exec` example
@@ -157,6 +160,9 @@ full_test_patterns:
 custom_mappings:
   spec/features/i18n_spec.rb:
     - config/locales/**/*.yml
+
+full_test_patterns:
+  - Gemfile.lock
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ patterns:
 exclude_patterns:
   - lib/batch/*.rb
 
+full_test_patterns:
+  - Gemfile.lock
+
 custom_mappings:
   spec/features/i18n_spec.rb:
     - config/locales/**/*.yml

--- a/lib/delta_test/cli.rb
+++ b/lib/delta_test/cli.rb
@@ -117,8 +117,8 @@ module DeltaTest
     #
     # @return {Boolean}
     ###
-    def run_full_tests?
-      @run_full_tests ||= Git.same_commit?(@options['base'], @options['head'])
+    def profile_mode?
+      @profile_mode ||= Git.same_commit?(@options['base'], @options['head'])
     end
 
     ###
@@ -154,10 +154,8 @@ module DeltaTest
       spec_files = nil
       args = []
 
-      force_run_full_tests = false
-
       begin
-        unless run_full_tests?
+        unless profile_mode?
           @list.load_table!
           @list.retrive_changed_files!(@options['base'], @options['head'])
 
@@ -167,8 +165,9 @@ module DeltaTest
             exit_with_message(0, 'Nothing to test')
           end
         end
-      rescue
-        force_run_full_tests = true
+      rescue TableNotFoundError
+        # force profile mode cuz we don't have a table
+        @profile_mode = true
       end
 
       @args.map! { |arg| Shellwords.escape(arg) }
@@ -188,7 +187,7 @@ module DeltaTest
         end
       end
 
-      if run_full_tests? || force_run_full_tests
+      if profile_mode?
         args << ('%s=%s' % [VERBOSE_FLAG, true]) if DeltaTest.verbose?
         args << ('%s=%s' % [ACTIVE_FLAG, true])
       end

--- a/lib/delta_test/cli.rb
+++ b/lib/delta_test/cli.rb
@@ -257,7 +257,10 @@ commands:
 
     exec <script> [-- <files>]
                    Execute test script using delta_test.
-                   Run command something like `delta_test list | xargs script'.
+                   if <base> and <head> is the same commit or no dependencies table is found,
+                   it'll run full test cases with a profile mode to create a table.
+                   Otherwise, it'll run test script with only related spec files
+                   passed by its arguments, like `delta_test list | xargs script'.
 HELP
     end
 

--- a/lib/delta_test/configuration.rb
+++ b/lib/delta_test/configuration.rb
@@ -55,6 +55,7 @@ module DeltaTest
       table_file
       patterns
       exclude_patterns
+      full_test_patterns
       custom_mappings
     ]
 
@@ -80,6 +81,10 @@ module DeltaTest
       self.exclude_patterns.is_a?(Array)
     end
 
+    validate :full_test_patterns, 'need to be an array' do
+      self.full_test_patterns.is_a?(Array)
+    end
+
     validate :custom_mappings, 'need to be a hash' do
       self.custom_mappings.is_a?(Hash)
     end
@@ -90,12 +95,13 @@ module DeltaTest
 
     def initialize
       update do |c|
-        c.base_path        = File.expand_path('.')
-        c.table_file       = 'tmp/.delta_test_dt'
-        c.files            = []
-        c.patterns         = []
-        c.exclude_patterns = []
-        c.custom_mappings  = {}
+        c.base_path          = File.expand_path('.')
+        c.table_file         = 'tmp/.delta_test_dt'
+        c.files              = []
+        c.patterns           = []
+        c.exclude_patterns   = []
+        c.full_test_patterns = []
+        c.custom_mappings    = {}
       end
     end
 

--- a/spec/lib/delta_test/cli_spec.rb
+++ b/spec/lib/delta_test/cli_spec.rb
@@ -154,7 +154,7 @@ describe DeltaTest::CLI do
 
   end
 
-  describe '#run_full_tests?' do
+  describe '#profile_mode?' do
 
     let(:map) do
       {
@@ -179,7 +179,7 @@ describe DeltaTest::CLI do
       end
 
       it 'should return true' do
-        expect(cli.run_full_tests?).to be(true)
+        expect(cli.profile_mode?).to be(true)
       end
 
     end
@@ -194,7 +194,7 @@ describe DeltaTest::CLI do
       end
 
       it 'should return false' do
-        expect(cli.run_full_tests?).to be(false)
+        expect(cli.profile_mode?).to be(false)
       end
 
     end
@@ -306,7 +306,7 @@ describe DeltaTest::CLI do
       context 'Full tests' do
 
         before do
-          allow(cli).to receive(:run_full_tests?).with(no_args).and_return(true)
+          allow(cli).to receive(:profile_mode?).with(no_args).and_return(true)
         end
 
         it 'should run script with a flag' do
@@ -325,7 +325,7 @@ describe DeltaTest::CLI do
       context 'Partial tests' do
 
         before do
-          allow(cli).to receive(:run_full_tests?).with(no_args).and_return(false)
+          allow(cli).to receive(:profile_mode?).with(no_args).and_return(false)
         end
 
         context 'Any related files' do

--- a/spec/lib/delta_test/related_spec_list_spec.rb
+++ b/spec/lib/delta_test/related_spec_list_spec.rb
@@ -171,8 +171,82 @@ describe DeltaTest::RelatedSpecList do
         end
       end
 
+      after do
+        DeltaTest.configure do |config|
+          config.custom_mappings = {}
+        end
+      end
+
       it 'should be included' do
         expect(list.related_spec_files).to eq(related_spec_files)
+      end
+
+    end
+
+    describe 'Run full tests' do
+
+      let(:full_spec_files) do
+        Set[
+          'spec/foo_spec.rb',
+          'spec/bar_spec.rb',
+          'spec/baz_spec.rb',
+          'spec/other_spec.rb',
+          'spec/mixed_spec.rb',
+        ]
+      end
+
+      context 'No file in full test patterns is changed' do
+
+        let(:changed_files) do
+          [
+            'spec/other_spec.rb',
+          ]
+        end
+
+        let(:related_spec_files) do
+          Set[
+            'spec/foo_spec.rb',
+            'spec/mixed_spec.rb',
+            'spec/baz_spec.rb',
+          ]
+        end
+
+        it 'should not return full spec files' do
+          expect(list.related_spec_files).not_to eq(full_spec_files)
+        end
+
+      end
+
+      context 'No file in full test patterns is changed' do
+
+        let(:full_test_patterns) do
+          [
+            'spec/other_spec.rb',
+          ]
+        end
+
+        let(:changed_files) do
+          [
+            'spec/other_spec.rb',
+          ]
+        end
+
+        before do
+          DeltaTest.configure do |config|
+            config.full_test_patterns = full_test_patterns
+          end
+        end
+
+        after do
+          DeltaTest.configure do |config|
+            config.full_test_patterns = []
+          end
+        end
+
+        it 'should return full spec files' do
+          expect(list.related_spec_files).to eq(full_spec_files)
+        end
+
       end
 
     end


### PR DESCRIPTION
## Why

If you update gem or install new one, for example, need to verify all test cases to be passed.


## What

Support `full_test_patterns` option in a configuration file.

```yaml
full_test_patterns:
  - Gemfile.lock
```



